### PR TITLE
Move PHPUnit to require dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     ],
     "require": {
         "php": ">=5.4.16",
-        "pimple/pimple": "~3.0",
-        "phpunit/phpunit": "^8.0"
+        "pimple/pimple": "~3.0"
     },
     "require-dev": {
-        "cakephp/cakephp": "~4.0"
+        "cakephp/cakephp": "~4.0",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Upgrading flexcenter to PHP 8 and had to bump the version of PHPUnit on our end, but this fork is not too happy about it.
Moves PHPUnit to require-dev instead of require.